### PR TITLE
Implement 'type' option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bspm
 Type: Package
 Title: Bridge to System Package Manager
-Version: 0.3.10.1
+Version: 0.3.10.2
 Authors@R: c(
     person("Iñaki", "Ucar", email="iucar@fedoraproject.org",
       role=c("aut", "cph", "cre"), comment=c(ORCID="0000-0001-6403-5550")))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,5 +19,5 @@ SystemRequirements: systemd, dbus-python, PyGObject, python-(dnf|apt|alpm)
 Suggests: tinytest
 URL: https://enchufa2.github.io/bspm/
 BugReports: https://github.com/Enchufa2/bspm/issues
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.2
 Roxygen: list(old_usage = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,9 @@
-# bspm 0.3.10.1
+# bspm 0.3.10.2
 
 - New function `available_sys()` returns a matrix of available packages with
   `"Package"`, `"Version"`, and `"Repository"` (#47 addressing #41).
+- Honor `type` option, set by default to `"both"`, which means 'use binary
+  if available and current, otherwise try source' (#48 addressing #46).
 
 # bspm 0.3.10
 

--- a/R/bridge.R
+++ b/R/bridge.R
@@ -40,7 +40,10 @@ backend_check <- function() {
     ))
 }
 
-backend_call <- function(method, pkgs=NULL) {
+backend_call <- function(method, pkgs) {
+  if (!missing(pkgs) && !length(pkgs))
+    return(invisible())
+
   if (root())
     return(root_call(method, pkgs))
 
@@ -60,7 +63,7 @@ root <- function() {
   Sys.info()["effective_user"] == "root"
 }
 
-root_call <- function(method, pkgs=NULL, sudo=NULL) {
+root_call <- function(method, pkgs, sudo=NULL) {
   tmp <- tmp2 <- tempfile()
   # workaround, see #13
   if (length(strsplit(tmp2, "/")[[1]]) == 3) {
@@ -72,7 +75,7 @@ root_call <- function(method, pkgs=NULL, sudo=NULL) {
 
   cmd <- system.file("service/bspm.py", package="bspm")
   args <- c(method, "-o", tmp)
-  if (!is.null(pkgs))
+  if (!missing(pkgs))
     args <- c(args, pkgs)
   if (!is.null(sudo)) {
     args <- c(cmd, args)
@@ -97,12 +100,12 @@ dbus_service_alive <- function() {
   return(TRUE)
 }
 
-dbus_call <- function(method, pkgs=NULL) {
+dbus_call <- function(method, pkgs) {
   source(system.file("service/dbus-paths", package="bspm"), local=TRUE)
 
   cmd <- Sys.which("busctl")
   args <- c("call", "--timeout=1h", BUS_NAME, OPATH, IFACE, method)
-  if (!is.null(pkgs))
+  if (!missing(pkgs))
     args <- c(args, "ias", Sys.getpid(), length(pkgs), pkgs)
   else args <- c(args, "i", Sys.getpid())
   out <- system2nowarn(cmd, args, stdout=TRUE, stderr=TRUE)
@@ -119,7 +122,7 @@ dbus_call <- function(method, pkgs=NULL) {
   out
 }
 
-sudo_call <- function(method, pkgs=NULL, force=FALSE) {
+sudo_call <- function(method, pkgs, force=FALSE) {
   if (!isatty(stdin()) && !force)
     cmd <- "pkexec"
   else cmd <- "sudo"

--- a/R/integration.R
+++ b/R/integration.R
@@ -2,8 +2,8 @@
 #'
 #' Functions to enable or disable the integration of \code{\link{install_sys}}
 #' into \code{\link{install.packages}}. When enabled, packages are installed
-#' transparently from system repositories if available, and from the configured
-#' \R repositories if not.
+#' transparently from system repositories if available, including dependencies,
+#' and from the configured \R repositories if not.
 #'
 #' @details To enable \pkg{bspm} system-wide by default, include the following:
 #'
@@ -15,6 +15,12 @@
 #' By default, enabling \pkg{bspm} triggers a check of the backend, and a
 #' warning is raised if the system service is required but not available. To
 #' avoid this check, \code{options(bspm.backend.check=FALSE)} can be set.
+#'
+#' Enabling \pkg{bspm} sets default installation \code{type} to \code{"both"},
+#' which means 'use binary if available and current, otherwise try source'.
+#' The action if there are source packages which are preferred is controlled by
+#' \code{getOption("install.packages.compile.from.source")}. Set this option to
+#' \code{"never"} to always prefer binaries over source packages.
 #'
 #' @seealso \code{\link{manager}}
 #'
@@ -34,14 +40,70 @@
 enable <- function() {
   if (getOption("bspm.backend.check", TRUE))
     backend_check()
-  expr <- quote(if (!is.null(repos)) pkgs <- bspm::install_sys(pkgs))
-  trace(utils::install.packages, expr, print=FALSE)
+
+  options(pkgType="both")
+
+  trace(utils::install.packages, print=FALSE, tracer=quote({
+    if (type == "both") {
+      if (is.null(repos))
+        stop("type == \"both\" cannot be used with 'repos = NULL'")
+
+      # get pkgs with non-installed dependencies
+      dbs <- available.packages(type="source")
+      inst <- row.names(installed.packages(.Library.site))
+      pkgs <- tools::package_dependencies(pkgs, dbs, recursive=TRUE)
+      pkgs <- lapply(pkgs, function(x) setdiff(x, inst))
+      pkgs <- unique(c(names(pkgs), unlist(pkgs, use.names=FALSE)))
+
+      # get available binaries and pkgs with later versions available
+      dbb <- bspm::available_sys()
+      row.names(dbb) <- tolower(row.names(dbb))
+      bins <- pkgs[tolower(pkgs) %in% row.names(dbb)]
+      srcs <- pkgs[! pkgs %in% bins]
+      binvers <- dbb[tolower(bins), "Version"]
+      srcvers <- dbs[bins, "Version"]
+      later <- as.numeric_version(binvers) < srcvers
+
+      # determine whether later versions should be installed
+      if (any(later)) {
+        msg <- ngettext(
+          sum(later),
+          "There is a binary version available but the source version is later",
+          "There are binary versions available but the source versions are later")
+        cat("\n", paste(strwrap(msg, indent = 2, exdent = 2), collapse = "\n"),
+            ":\n", sep = "")
+        print(data.frame(`binary` = binvers, `source` = srcvers,
+                         row.names = bins, check.names = FALSE)[later, ])
+        cat("\n")
+        action <- getOption("install.packages.compile.from.source", "interactive")
+        if (action == "interactive" && interactive()) {
+          msg <- gettext("Do you want to install later versions from sources?")
+          res <- utils::askYesNo(msg)
+          if (is.na(res)) stop("Cancelled by user")
+          if (!isTRUE(res)) later <- FALSE
+        } else if (action == "never") {
+          cat("  Binaries will be installed\n")
+          later <- FALSE
+        }
+      }
+
+      # install binaries and forward the rest
+      pkgs <- c(bspm::install_sys(bins[!later]), bins[later], srcs)
+      type <- "source"
+    } else if (type == "binary") {
+      # try just binaries and fail otherwise
+      if (!length(pkgs <- bspm::install_sys(pkgs)))
+        type <- "source"
+    }
+  }))
+
   invisible()
 }
 
 #' @name integration
 #' @export
 disable <- function() {
+  options(pkgType="source")
   untrace(utils::install.packages)
   invisible()
 }

--- a/R/integration.R
+++ b/R/integration.R
@@ -44,7 +44,11 @@ enable <- function() {
   options(pkgType="both")
 
   trace(utils::install.packages, print=FALSE, tracer=quote({
-    if (type == "both") {
+    if (grepl("[.]tar[.](gz|bz2|xz)$", pkgs)) {
+      repos <- NULL
+      type <- "source"
+      message("inferring 'repos = NULL' from 'pkgs'")
+    } else if (type == "both") {
       if (is.null(repos))
         stop("type == \"both\" cannot be used with 'repos = NULL'")
 

--- a/R/integration.R
+++ b/R/integration.R
@@ -44,7 +44,11 @@ enable <- function() {
   options(pkgType="both")
 
   trace(utils::install.packages, print=FALSE, tracer=quote({
-    if (grepl("[.]tar[.](gz|bz2|xz)$", pkgs)) {
+    if (missing(pkgs)) stop("no packages were specified")
+
+    if (is.null(repos)) {
+      type <- "source"
+    } else if (grepl("[.]tar[.](gz|bz2|xz)$", pkgs)) {
       repos <- NULL
       type <- "source"
       message("inferring 'repos = NULL' from 'pkgs'")

--- a/R/manager.R
+++ b/R/manager.R
@@ -21,15 +21,6 @@
 #' be used (e.g., in a containerized environment such as a Fedora Toolbox) for
 #' every call, and then uses \code{sudo} accordingly.
 #'
-#' By default, if a package is not available in the system repositories, it is
-#' installed from R's configured repositories along with all its dependencies.
-#' This behavior can be changed via \code{options(bspm.always.install.deps=TRUE)},
-#' which tries to install from system repositories recursive dependencies of
-#' those packages that are not available. For example, if \pkg{A} depends on
-#' \pkg{B}, and \pkg{B} is available in the system repositories but \pkg{A} is
-#' not, then only \pkg{A} will be installed from CRAN with this option enabled,
-#' and both will be installed from CRAN with this option disabled (default).
-#'
 #' @seealso \code{\link{integration}}
 #'
 #' @examples
@@ -46,15 +37,7 @@
 #'
 #' @name manager
 #' @export
-install_sys <- function(pkgs) {
-  not.avail <- backend_call("install", pkgs)
-  if (length(not.avail) && getOption("bspm.always.install.deps", FALSE)) {
-    deps <- tools::package_dependencies(not.avail, recursive=TRUE)
-    deps <- unique(unlist(deps, use.names=FALSE))
-    if (length(deps)) backend_call("install", deps)
-  }
-  invisible(not.avail)
-}
+install_sys <- function(pkgs) invisible(backend_call("install", pkgs))
 
 #' @name manager
 #' @export

--- a/inst/tinytest/test_integration.R
+++ b/inst/tinytest/test_integration.R
@@ -5,7 +5,7 @@ enable()
 expect_true(inherits(utils::install.packages, "functionWithTrace"))
 
 tracer <- paste(body(utils::install.packages), collapse="")
-expected <- "if (!is.null(repos)) pkgs <- bspm::install_sys(pkgs)"
+expected <- "pkgs <- bspm::install_sys(pkgs)"
 expect_true(grepl(expected, tracer, fixed=TRUE))
 
 disable()

--- a/inst/tinytest/test_manager.R
+++ b/inst/tinytest/test_manager.R
@@ -25,12 +25,6 @@ pkgs <- install_sys(c("Rcpp", "simmer"))
 expect_equal(pkgs, "simmer")
 expect_equal(installed, "Rcpp")
 
-options(bspm.always.install.deps=TRUE)
-installed <- NULL
-pkgs <- install_sys(c("Rcpp", "simmer"))
-expect_equal(pkgs, "simmer")
-expect_equal(installed, c("Rcpp", "Rcpp", "magrittr"))
-
 # restore mocked functions and options
 options(bspm.always.install.deps=NULL)
 mock("available.packages", .available.packages, "utils")

--- a/man/integration.Rd
+++ b/man/integration.Rd
@@ -13,8 +13,8 @@ disable()
 \description{
 Functions to enable or disable the integration of \code{\link{install_sys}}
 into \code{\link{install.packages}}. When enabled, packages are installed
-transparently from system repositories if available, and from the configured
-\R repositories if not.
+transparently from system repositories if available, including dependencies,
+and from the configured \R repositories if not.
 }
 \details{
 To enable \pkg{bspm} system-wide by default, include the following:
@@ -27,6 +27,12 @@ move that line to the user's \code{~/.Rprofile} instead.
 By default, enabling \pkg{bspm} triggers a check of the backend, and a
 warning is raised if the system service is required but not available. To
 avoid this check, \code{options(bspm.backend.check=FALSE)} can be set.
+
+Enabling \pkg{bspm} sets default installation \code{type} to \code{"both"},
+which means 'use binary if available and current, otherwise try source'.
+The action if there are source packages which are preferred is controlled by
+\code{getOption("install.packages.compile.from.source")}. Set this option to
+\code{"never"} to always prefer binaries over source packages.
 }
 \examples{
 \dontrun{

--- a/man/manager.Rd
+++ b/man/manager.Rd
@@ -46,15 +46,6 @@ whether it is running in an environment where password-less \code{sudo} can
 be used (e.g., in a containerized environment such as a Fedora Toolbox) for
 every call, and then uses \code{sudo} accordingly.
 
-By default, if a package is not available in the system repositories, it is
-installed from R's configured repositories along with all its dependencies.
-This behavior can be changed via \code{options(bspm.always.install.deps=TRUE)},
-which tries to install from system repositories recursive dependencies of
-those packages that are not available. For example, if \pkg{A} depends on
-\pkg{B}, and \pkg{B} is available in the system repositories but \pkg{A} is
-not, then only \pkg{A} will be installed from CRAN with this option enabled,
-and both will be installed from CRAN with this option disabled (default).
-
 The \code{discover} method is only needed when e.g. a new repository
 is added that contains packages with different prefixes (for example, your
 system repositories may provide packages called \code{r-cran-*} and


### PR DESCRIPTION
Enabling bspm now sets default `type` to `"both"`, which means 'use binary if available and current, otherwise try source' (in interactive sessions, the user is asked about this). Adding e.g. the Rcpp drat should install it from there by default in non-interactive sessions.

Closes #46.