### PR TITLE
Support r and its argv in scripts

### DIFF
--- a/R/scripts.R
+++ b/R/scripts.R
@@ -23,7 +23,14 @@ scripts <- function(x, ...) {
     quit(status=status)
   }
 
-  argv <- commandArgs(TRUE)
+  ## Borrowed with love from docopt.R: coexist with littler
+  if (exists("argv", where = .GlobalEnv, inherits = FALSE)) {
+      argv <- get("argv", envir = .GlobalEnv)
+      if (is.null(argv)) argv <- character()
+  } else {
+      argv <- commandArgs(TRUE)
+  }
+
   scrp <- list.files(system.file("scripts", package="bspm"), full.names=TRUE)
   names(scrp) <- tools::file_path_sans_ext(basename(scrp))
 

--- a/R/scripts.R
+++ b/R/scripts.R
@@ -25,10 +25,10 @@ scripts <- function(x, ...) {
 
   ## Borrowed with love from docopt.R: coexist with littler
   if (exists("argv", where = .GlobalEnv, inherits = FALSE)) {
-      argv <- get("argv", envir = .GlobalEnv)
-      if (is.null(argv)) argv <- character()
+    argv <- get("argv", envir = .GlobalEnv)
+    if (is.null(argv)) argv <- character()
   } else {
-      argv <- commandArgs(TRUE)
+    argv <- commandArgs(TRUE)
   }
 
   scrp <- list.files(system.file("scripts", package="bspm"), full.names=TRUE)


### PR DESCRIPTION
The `scripts` tricks is rather lovely, I may borrow that.

Sadly `Rscript` chose a weird route towards a more C-like `argv`, the following change (long used in `docopt`) should extend over to `littler`.